### PR TITLE
Reset Markers on all players when player dies.

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -6,7 +6,9 @@ if (hasInterface) then {
             [] spawn {
                 sleep 0.5;
                 [player] call potato_assignGear_fnc_assignGearMan;
-                [] call potato_markers_initMarkerHash;
+                {
+                    ["potato_adminMenu_resetMarkers", [_x], [_x]] call CBA_fnc_targetEvent;
+                } forEach allPlayers;
             };
         }];
     };


### PR DESCRIPTION
This might be a little heavy handed as it will reset all markers for all players. Might need to refine at some point and make it for only those in the flight. This would be less impact on the rest of the server. But as player counts for the mission are low currently, I don't see this being too much of an issue for the sake of testing. 